### PR TITLE
Fix file name typo

### DIFF
--- a/Publication2020_MATLAB/fig7.m
+++ b/Publication2020_MATLAB/fig7.m
@@ -345,7 +345,7 @@ for k = 1:n
         loglamsNew = -8:0.1:-4;
         
         % also load data from Snapshots (created in fig8.m)
-        load('data/cfShape_snap_9:27.mat')
+        load('data/cfShape_snap_9by27.mat')
         % loads PDE_snap, ABM_snap, peaks_snap, widths_snap, skews_snap
 %         S = PDE_snap{1,k};
 %         M = PDE_snap{2,k};

--- a/Publication2020_MATLAB/fig8.m
+++ b/Publication2020_MATLAB/fig8.m
@@ -204,7 +204,7 @@ if new_data == 1
     % compute skewness
     skews_snap(1,k) = -sum((X-cm).^3.*(rho)/N)*dx/(widths_snap(1,k))^3;
 else
-    load('data/cfShape_snap_9:27.mat')
+    load('data/cfShape_snap_9by27.mat')
     % loads PDE_snap, ABM_snap, peaks_snap, widths_snap, skews_snap
     S = PDE_snap{1,k};
     M = PDE_snap{2,k};


### PR DESCRIPTION
The load function fails because of a typo in the .mat name.